### PR TITLE
Test face diarization with OpenFace on election debate data

### DIFF
--- a/explore_openface.ipynb
+++ b/explore_openface.ipynb
@@ -24,6 +24,7 @@
     "from urllib.request import urlopen, Request\n",
     "import subprocess\n",
     "import os\n",
+    "import IPython\n",
     "import docker\n",
     "import pandas as pd\n",
     "\n",
@@ -154,15 +155,49 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c803fe62-188e-4c08-bac2-842d8dfef705",
+   "id": "48d97496-86c8-43ef-ab4a-4b66c598b7d5",
    "metadata": {},
    "source": [
-    "The results from OpenFace are stored in the `/processed` directory. It contains the video file `test_video_single.avi` which is overlayed with the extracted facial features (not only action units). The face tracking and feature extraction seems to perform well for a single face which is directed to a point next to the camera. The directory also contains the extracted features in the file `test_video_single.csv`:"
+    "The results from OpenFace are stored in the `/processed` directory. It contains the video file `test_video_single.avi` which is overlayed with the extracted facial features (not only action units). The face tracking and feature extraction seems to perform well for a single face which is directed to a point next to the camera. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 20,
+   "id": "b4096a2a-0ba2-4542-957e-b708f7cebe17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<video src=\"video/test_video_single.mp4\" controls  >\n",
+       "      Your browser does not support the <code>video</code> element.\n",
+       "    </video>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Video object>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "IPython.display.Video(\"processed/test_video_single.mp4\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ad414b2-c0d2-45b2-a20a-6c5e36937812",
+   "metadata": {},
+   "source": [
+    "The directory also contains the extracted features in the file `test_video_single.csv`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "a65d393f-54fe-45bd-8acd-3c4330963ffc",
    "metadata": {},
    "outputs": [],
@@ -172,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "99d7ea92-da9b-4243-9a85-b66cfc664978",
    "metadata": {},
    "outputs": [
@@ -239,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "56faece5-5e37-4206-8f69-ae1c1b76dc61",
    "metadata": {},
    "outputs": [],
@@ -270,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "a5fc692a-2f86-4562-92dd-9a5d94b462d9",
    "metadata": {},
    "outputs": [
@@ -288,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ae6b0bd7-2150-4061-b52e-df18d4c9092f",
    "metadata": {},
    "outputs": [
@@ -318,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "d9197d0e-d33d-44b0-8486-e65a5c07f97f",
    "metadata": {},
    "outputs": [],
@@ -328,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "a951a4d9-6a12-407e-9a16-c079ba790862",
    "metadata": {},
    "outputs": [
@@ -401,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "e7ffe8f8-575b-499f-aba3-8887bcb1085c",
    "metadata": {},
    "outputs": [
@@ -419,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "76851452-e5f9-4c7e-ab9d-a27a5333a84a",
    "metadata": {},
    "outputs": [
@@ -449,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "540d5a91-4bb7-42c5-8c4b-29ee63c76deb",
    "metadata": {},
    "outputs": [],
@@ -459,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "ed674427-cd68-42fe-b865-6d9e7b630f40",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
Closes #10 

Adds a notebook for testing face diarization with OpenFace on election debate data. The data is not publicly availabel and the notebook is not documented because it is just a preliminar test (and uses functions created in the exploration notebooks).